### PR TITLE
[Refactor] 채팅 서버 인증 방식 수정

### DIFF
--- a/apps/chat/src/auth/jwt-auth.guard.ts
+++ b/apps/chat/src/auth/jwt-auth.guard.ts
@@ -8,10 +8,11 @@ import { ErrorStatus } from 'src/common/responses/exceptions/errorStatus';
 export class JWTAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
     const client = context.switchToWs().getClient<Socket>();
+    const authorization = client.handshake.auth.accessToken || client.handshake.headers.accesstoken;
 
     return {
       headers: {
-        authorization: client.handshake.auth.accessToken,
+        authorization,
       },
     };
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #8 

## ✨ 구현 기능 명세
- 채팅 서버 인증 방식을 두 가지 방법이 가능하도록 수정했습니다.
- 이제 따로 수정을 하지 않아도 postman에서도 인증을 통해 socket 테스트를 할 수 있습니다!